### PR TITLE
Add instructions for JS wrapper

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -429,3 +429,9 @@ BOARD-ID | The ID of the specific board you want to retreive
 ## Platform Payloads (Coming Soon)
 
 In near future we will be giving you access to get platform ready JSON payload for any given message within the board. 
+
+# Wrappers
+
+We're actively working on creating wrappers that will make interacting with our API a breeze.
+
+* [Botmock-JS (Javascript)](https://github.com/obaid/botmock-js)


### PR DESCRIPTION
Self explanatory. Just creates a link in the docs to refer to a wrapper that devs can use. Documentation for the wrapper exists in the README in the repo.